### PR TITLE
fix: weak-link CoreNFC to prevent launch crash on iOS < 17

### DIFF
--- a/unicocheck-ios.podspec
+++ b/unicocheck-ios.podspec
@@ -19,6 +19,15 @@ Pod::Spec.new do |spec|
     "*.xcframework",
   ]
 
+  # iOS 17 split CoreNFC and added a sub-framework that only exists on iOS 17+.
+  # Weak-linking keeps the reference as LC_LOAD_WEAK_DYLIB in the consumer binary,
+  # avoiding a "Library not loaded" launch crash on iOS < 17.
+  spec.weak_frameworks = ['CoreNFC', 'CoreBluetooth']
+
+  # weak_frameworks above only covers the CoreNFC umbrella; this flag ensures the
+  # split sub-framework is weak-linked explicitly in the consumer's final link.
+  spec.user_target_xcconfig = { 'OTHER_LDFLAGS' => '$(inherited) -weak_framework _CoreNFC_UIKit' }
+
   spec.resource_bundles = {"unicocheck-ios" => ["AcessoBio.xcframework/ios-arm64/AcessoBio.framework/PrivacyInfo.xcprivacy"]}
 
 end


### PR DESCRIPTION
## What

Weak-link CoreNFC in the podspec to prevent a launch crash on iOS < 17.

iOS 17 split the CoreNFC framework and introduced a sub-framework that only exists on iOS 17+. A strong load command to it aborts launch on iOS 13–16. This change:

- Declares `CoreNFC`/`CoreBluetooth` as `weak_frameworks`.
- Weak-links the split sub-framework via `user_target_xcconfig` `OTHER_LDFLAGS` (`weak_frameworks` alone does not downgrade the split sub-framework).

Result: the consumer binary keeps a weak load command, so on iOS < 17 the missing framework is skipped at launch instead of aborting. The relevant API is availability-gated to iOS 17+, so nothing from it is ever called below that.

## Scope

Podspec-only. No binaries, no behavior change. Version is intentionally **not** bumped — it is set by the release pipeline.

## Release Checklist

- [ ] Production environment build — N/A (podspec-only, no rebuild)
- [ ] Spec.version updated — N/A (version driven by release pipeline)
- [ ] E2E tests — N/A (no runtime/behavior change)
- [ ] Release notes updated (pt-br/en/es) — N/A (ships with next release)